### PR TITLE
Fix image resizing crash

### DIFF
--- a/media_engine.py
+++ b/media_engine.py
@@ -98,7 +98,13 @@ def create_image_clips(image_paths: List[str], resolution: Tuple[int, int], tota
                 source_image_clip_obj = ImageClip(current_image_path_for_moviepy)
                 source_image_clip_obj.fps = video_fps
 
-                current_moviepy_clip = source_image_clip_obj.resized(height=resolution[1])
+                resize_attr = getattr(source_image_clip_obj, 'resize', None)
+                if not resize_attr:
+                    resize_attr = getattr(source_image_clip_obj, 'resized', None)
+                if resize_attr:
+                    current_moviepy_clip = resize_attr(height=resolution[1])
+                else:
+                    current_moviepy_clip = source_image_clip_obj
                 
                 if current_moviepy_clip.w > resolution[0]:
                     if CROP_FUNCTION_AVAILABLE:
@@ -122,10 +128,12 @@ def create_image_clips(image_paths: List[str], resolution: Tuple[int, int], tota
 
                     clip_to_composite = final_clip_item
                     if final_clip_item.w > resolution[0] or final_clip_item.h > resolution[1]:
-                        if final_clip_item.w / final_clip_item.h > resolution[0] / resolution[1]:
-                             clip_to_composite = final_clip_item.resized(width=resolution[0])
-                        else:
-                             clip_to_composite = final_clip_item.resized(height=resolution[1])
+                        resize_attr = getattr(final_clip_item, 'resize', None) or getattr(final_clip_item, 'resized', None)
+                        if resize_attr:
+                            if final_clip_item.w / final_clip_item.h > resolution[0] / resolution[1]:
+                                clip_to_composite = resize_attr(width=resolution[0])
+                            else:
+                                clip_to_composite = resize_attr(height=resolution[1])
                     
                     if getattr(clip_to_composite, 'fps', None) is None: clip_to_composite.fps = video_fps
                     

--- a/moviepy/__init__.py
+++ b/moviepy/__init__.py
@@ -19,6 +19,19 @@ except Exception:
             pass
         def write_videofile(self, path, *args, **kwargs):
             open(path, 'wb').close()
+        def resize(self, **kwargs):
+            w = kwargs.get('width')
+            h = kwargs.get('height')
+            if w and h:
+                self.size = (w, h)
+            elif w and self.size:
+                self.size = (w, self.size[1])
+            elif h and self.size:
+                self.size = (self.size[0], h)
+            return self
+        # moviepy 2.x compatibility alias
+        def resized(self, **kwargs):
+            return self.resize(**kwargs)
     class TextClip(_BaseClip):
         def __init__(self, text='', font=None, font_size=12, color='white', **kw):
             super().__init__(**kw)


### PR DESCRIPTION
## Summary
- handle resize() or resized() for ImageClip in media_engine
- add resize/resized helpers to moviepy stub for compatibility

## Testing
- `python3 run_tests.py` *(fails: Google Sheets integration skipped)*

------
https://chatgpt.com/codex/tasks/task_e_684774fe397c83208d1e5f9db1beda31